### PR TITLE
Fix: Update GitHub Actions workflow to build Vite/React app

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,13 +31,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20' # Specify a Node.js version
+      - name: Install dependencies
+        run: npm ci # or yarn install
+      - name: Build project
+        run: npm run build # or yarn build
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          # Upload build output directory
+          path: './dist' # Assuming 'dist' is the output directory
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
The previous workflow attempted to deploy the entire repository as a static site, which is incorrect for a Vite/React application.

This commit updates the workflow to:
- Set up Node.js
- Install dependencies using npm
- Build the project using npm
- Deploy the generated `dist` directory to GitHub Pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved deployment process for static content to GitHub Pages, ensuring only built files are deployed for greater efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->